### PR TITLE
Fix manifest links

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "/images/android-chrome-192x192.png",
+            "src": "images/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/images/android-chrome-512x512.png",
+            "src": "images/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }


### PR DESCRIPTION
Since links are relative to `/loader/`, even though the expected result is `/loader/images/android-chrome-192x192.png`, the result is `/images/android-chrome-192x192.png`. Same for the `512x512` image. This PR makes the links relative instead of absolute on the webmanifest.